### PR TITLE
Updated README file to accommodate SDK upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,32 @@ This means data masking is super fast and happens on a programming level before 
 
 ### Install the SDK
 
-Add the following dependency:
+Add the subsequent dependency to your `pom.xml` file while ensuring it aligns with your Spring Boot version:
+
+For Spring Boot `2.4.X` with `Java 8` and higher:
 
 ```xml
 <dependencies>
+  <!-- Other dependencies -->
     <dependency>
         <groupId>com.treblle</groupId>
         <artifactId>treblle-spring-boot-starter</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </dependency>
+  <!-- Other dependencies -->
+</dependencies>
+```
+
+For Spring Boot `3.X` with `Java 8` and higher:
+```xml
+<dependencies>
+  <!-- Other dependencies -->
+    <dependency>
+        <groupId>com.treblle</groupId>
+        <artifactId>treblle-spring-boot-starter</artifactId>
+        <version>2.0.0</version>
+    </dependency>
+  <!-- Other dependencies -->
 </dependencies>
 ```
 
@@ -89,15 +106,26 @@ Annotate the desired configuration with `@EnableTreblle`
 @EnableTreblle
 @SpringBootApplication
 public class MyApplication {
-    ...
+  
+    public static void main(String[] args) {
+        SpringApplication.run(MyApplication.class, args);
+  }
 }
 ```
 
-Configure the following properties:
+Configure the following properties in your `application.properties` file:
 
-```csv
+```properties
 treblle.apiKey=<API_KEY>
 treblle.projectId=<PROJECT_ID>
+```
+
+In case you are using the `application.yml` file:
+
+```yaml
+treblle:
+  api-key: <API_KEY>
+  project-id: <PROJECT_ID>
 ```
 
 That's it. Your API requests and responses are now being sent to your Treblle project.


### PR DESCRIPTION
List of things that changed in the readme file:
1. updated instructions for adding Treblle dependencies to your spring boot 3.X projects.
2. updated the Treblle dependency existing in the readme from v1.0.0 to v1.0.1 (I noticed a more recent dependency for spring 2.4.X was published by Ivo, but wasn't updated in the readme). I ensured it was working before I made this change.
3. updated instructions for adding the apiKey and projectId to spring boot projects, using either a properties file or yaml file.